### PR TITLE
Refine serverless handler typing

### DIFF
--- a/ems-backend/api/index.ts
+++ b/ems-backend/api/index.ts
@@ -28,5 +28,37 @@ app.use(async (req, _res, next) => {
   }
 });
 
+const expressHandler = serverless(app);
+
+type ExpressHandlerArgs = Parameters<typeof expressHandler>;
+
+function getEventPath(event: ExpressHandlerArgs[0]): string {
+  if (event && typeof event === "object") {
+    if ("path" in event && typeof (event as { path?: unknown }).path === "string") {
+      return (event as { path?: string }).path ?? "";
+    }
+    if ("rawPath" in event && typeof (event as { rawPath?: unknown }).rawPath === "string") {
+      return (event as { rawPath?: string }).rawPath ?? "";
+    }
+  }
+  return "";
+}
+
+function shouldSkipDB(path: string) {
+  return (
+    path === "/health" ||
+    path.startsWith("/docs") || // swagger ui + assets
+    path === "/docs.json"
+  );
+}
+
+const handler: typeof expressHandler = async (event, context) => {
+  const path = getEventPath(event);
+  if (!shouldSkipDB(path)) {
+    await ensureDB();
+  }
+  return expressHandler(event, context);
+};
+
 export const config = { api: { bodyParser: false } };
-export default serverless(app);
+export default handler;


### PR DESCRIPTION
## Summary
- wrap the serverless express handler to reuse its inferred argument types
- ensure the wrapper only awaits a database connection for API routes before delegating

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6be7b560c83228edb0f77e21d7e05